### PR TITLE
Align factor returns by timestamp

### DIFF
--- a/phase1/backtest_engine.py
+++ b/phase1/backtest_engine.py
@@ -1,8 +1,6 @@
 """Vectorized backtest engine for single-factor evaluation."""
 from __future__ import annotations
 
-import numpy as np
-
 try:  # pragma: no cover
     import pandas as pd
 except ModuleNotFoundError:  # pragma: no cover
@@ -30,26 +28,30 @@ class SimpleBacktestEngine:
 
     def backtest_factor(self, data: "pd.DataFrame", signals: "pd.Series") -> dict:
         close = data["close"].astype(float)
-        returns = close.pct_change().fillna(0.0).to_numpy()
-        future_returns = close.pct_change().shift(-1).fillna(0.0).to_numpy()
+        returns = close.pct_change().fillna(0.0)
+        future_returns = returns.shift(-1).fillna(0.0).to_numpy(dtype=float)
         raw_signals = signals.fillna(0.0).to_numpy(dtype=float)
-        positions = signals.shift(1).fillna(0.0).to_numpy() * self.allocation
-        strategy_returns = returns * positions
+        positions = signals.shift(1).fillna(0.0) * self.allocation
+        strategy_returns = (returns * positions).astype(float)
 
-        trade_changes = np.abs(np.diff(np.concatenate([[0.0], positions])))
+        previous_positions = positions.shift(1).fillna(0.0)
+        trade_changes = (positions - previous_positions).abs()
         trade_cost = self.costs.calculate_total_cost(self.initial_capital * self.allocation)
         cost_returns = (trade_changes > 0).astype(float) * (trade_cost / self.initial_capital)
-        strategy_returns -= cost_returns
+        strategy_returns = strategy_returns - cost_returns
 
-        equity_curve = self.initial_capital * np.cumprod(1 + strategy_returns)
-        gains = strategy_returns[strategy_returns > 0]
-        losses = strategy_returns[strategy_returns < 0]
-        trades = strategy_returns[trade_changes > 0]
+        equity_curve = self.initial_capital * (1 + strategy_returns).cumprod()
+        strategy_array = strategy_returns.to_numpy(dtype=float)
+        gains = strategy_returns[strategy_returns > 0].to_numpy(dtype=float)
+        losses = strategy_returns[strategy_returns < 0].to_numpy(dtype=float)
+        trades = strategy_returns[trade_changes > 0].to_numpy(dtype=float)
 
-        sharpe = PerformanceMetrics.calculate_sharpe_ratio(strategy_returns)
-        stability = PerformanceMetrics.calculate_stability(strategy_returns)
+        sharpe = PerformanceMetrics.calculate_sharpe_ratio(strategy_array)
+        stability = PerformanceMetrics.calculate_stability(strategy_array)
         profit_factor = PerformanceMetrics.calculate_profit_factor(gains, losses)
-        max_drawdown = PerformanceMetrics.calculate_max_drawdown(equity_curve)
+        max_drawdown = PerformanceMetrics.calculate_max_drawdown(
+            equity_curve.to_numpy(dtype=float)
+        )
         win_rate = float((trades > 0).mean()) if trades.size else 0.0
         information_coefficient = PerformanceMetrics.calculate_information_coefficient(
             raw_signals, future_returns

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -36,6 +36,8 @@ def test_backtest_engine_scales_returns_with_allocation(monkeypatch):
     result_full = engine_full.backtest_factor(data, signals)
     result_partial = engine_partial.backtest_factor(data, signals)
 
+    assert isinstance(result_full["returns"], pd.Series)
+    assert list(result_full["returns"].index) == list(data.index)
     assert np.allclose(result_partial["returns"], result_full["returns"] * 0.25)
     assert result_full["trades_count"] == result_partial["trades_count"]
 

--- a/utils/factor_cache.py
+++ b/utils/factor_cache.py
@@ -91,9 +91,15 @@ class FactorCache:
         if data is None:
             return None
         try:
-            if pd is not None and isinstance(data, pd.DataFrame):
-                sample = data.tail(min(len(data), 200))
-                payload = sample.to_json(date_format="iso", orient="split").encode()
+            if pd is not None:
+                if isinstance(data, pd.DataFrame):
+                    sample = data.tail(min(len(data), 200))
+                    payload = sample.to_json(date_format="iso", orient="split").encode()
+                elif isinstance(data, pd.Series):
+                    sample = data.tail(min(len(data), 200))
+                    payload = sample.to_json(date_format="iso", orient="split").encode()
+                else:
+                    payload = pickle.dumps(data, protocol=pickle.HIGHEST_PROTOCOL)
             else:
                 payload = pickle.dumps(data, protocol=pickle.HIGHEST_PROTOCOL)
             return hashlib.sha1(payload).hexdigest()


### PR DESCRIPTION
## Summary
- keep SimpleBacktestEngine strategy returns aligned with the input index and expose them as pandas Series
- combine factor returns in MultiFactorCombiner using timestamp-aware alignment while preserving combined return history
- cover the new structures with tests and allow the factor cache to hash pandas Series inputs

## Testing
- pytest tests/test_backtest_engine.py tests/test_multi_factor_combiner.py tests/test_parallel_factor_explorer.py

------
https://chatgpt.com/codex/tasks/task_e_68cf02b5e990832a8c17fe2e83f28cbf