### PR TITLE
Expose combiner configuration through CLI

### DIFF
--- a/application/configuration.py
+++ b/application/configuration.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+from config import CombinerConfig
 from utils.validation import validate_symbol
 
 
@@ -24,6 +25,7 @@ class AppSettings:
     parallel_mode: str = "off"
     max_workers: Optional[int] = None
     memory_limit_mb: Optional[int] = None
+    combiner_config: CombinerConfig = field(default_factory=CombinerConfig)
 
     @classmethod
     def from_cli_args(cls, args: object) -> "AppSettings":
@@ -49,6 +51,16 @@ class AppSettings:
             else (int(memory_limit_env) if memory_limit_env else None)
         )
 
+        combiner_defaults = CombinerConfig()
+        combiner_config = CombinerConfig(
+            top_n=int(getattr(args, "combiner_top_n", combiner_defaults.top_n)),
+            max_factors=int(getattr(args, "combiner_max_factors", combiner_defaults.max_factors)),
+            min_sharpe=float(getattr(args, "combiner_min_sharpe", combiner_defaults.min_sharpe)),
+            min_information_coefficient=float(
+                getattr(args, "combiner_min_ic", combiner_defaults.min_information_coefficient)
+            ),
+        )
+
         return cls(
             symbol=symbol,
             phase=phase,
@@ -61,6 +73,7 @@ class AppSettings:
             parallel_mode=parallel_mode,
             max_workers=max_workers,
             memory_limit_mb=memory_limit,
+            combiner_config=combiner_config,
         )
 
 

--- a/application/container.py
+++ b/application/container.py
@@ -127,6 +127,7 @@ class ServiceContainer:
         return CombinerType(
             self.settings.symbol,
             phase1_results,
+            config=self.settings.combiner_config,
             data_loader=self.data_loader(),
         )
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import argparse
 from typing import Iterable, Sequence
 
+from config import CombinerConfig
+
 try:  # pragma: no cover - optional dependency guard
     import pandas as pd
 except ModuleNotFoundError:  # pragma: no cover - handled via runtime error
@@ -17,6 +19,7 @@ from utils.logging import configure
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="港股因子探索系统")
+    combiner_defaults = CombinerConfig()
     parser.add_argument("--symbol", required=True, help="股票代码，如: 0700.HK")
     parser.add_argument("--phase", choices=["phase1", "phase2", "both"], default="both")
     parser.add_argument("--reset", action="store_true", help="重置数据库")
@@ -48,6 +51,30 @@ def _build_parser() -> argparse.ArgumentParser:
         "--memory-limit-mb",
         type=int,
         help="内存监控阈值，超过后输出警告信息",
+    )
+    parser.add_argument(
+        "--combiner-top-n",
+        type=int,
+        default=combiner_defaults.top_n,
+        help="阶段2中纳入多因子组合评估的顶尖单因子数量",
+    )
+    parser.add_argument(
+        "--combiner-max-factors",
+        type=int,
+        default=combiner_defaults.max_factors,
+        help="组合生成时每个策略允许的最大因子个数",
+    )
+    parser.add_argument(
+        "--combiner-min-sharpe",
+        type=float,
+        default=combiner_defaults.min_sharpe,
+        help="筛选阶段2因子及策略时所需的最低夏普比率",
+    )
+    parser.add_argument(
+        "--combiner-min-ic",
+        type=float,
+        default=combiner_defaults.min_information_coefficient,
+        help="筛选因子时所需的最小信息系数绝对值",
     )
     return parser
 


### PR DESCRIPTION
## Summary
- add CLI options for controlling combiner selection thresholds with defaults from `CombinerConfig`
- propagate parsed combiner settings into `AppSettings` and service wiring so the combiner receives the configured values

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68cf06524934832a844958dce0790d84