### PR TITLE
Add environment fallback for combiner configuration

### DIFF
--- a/application/configuration.py
+++ b/application/configuration.py
@@ -25,7 +25,7 @@ class AppSettings:
     parallel_mode: str = "off"
     max_workers: Optional[int] = None
     memory_limit_mb: Optional[int] = None
-    combiner_config: CombinerConfig = field(default_factory=CombinerConfig)
+    combiner: CombinerConfig = field(default_factory=CombinerConfig)
 
     @classmethod
     def from_cli_args(cls, args: object) -> "AppSettings":
@@ -52,12 +52,37 @@ class AppSettings:
         )
 
         combiner_defaults = CombinerConfig()
+
+        def resolve_combiner_value(arg_name: str, env_name: str, caster, default):
+            arg_value = getattr(args, arg_name, None)
+            if arg_value is not None:
+                return caster(arg_value)
+            env_value = os.environ.get(env_name)
+            if env_value is not None:
+                return caster(env_value)
+            return default
+
         combiner_config = CombinerConfig(
-            top_n=int(getattr(args, "combiner_top_n", combiner_defaults.top_n)),
-            max_factors=int(getattr(args, "combiner_max_factors", combiner_defaults.max_factors)),
-            min_sharpe=float(getattr(args, "combiner_min_sharpe", combiner_defaults.min_sharpe)),
-            min_information_coefficient=float(
-                getattr(args, "combiner_min_ic", combiner_defaults.min_information_coefficient)
+            top_n=resolve_combiner_value(
+                "combiner_top_n", "HK_DISCOVERY_COMBINER_TOP_N", int, combiner_defaults.top_n
+            ),
+            max_factors=resolve_combiner_value(
+                "combiner_max_factors",
+                "HK_DISCOVERY_COMBINER_MAX_FACTORS",
+                int,
+                combiner_defaults.max_factors,
+            ),
+            min_sharpe=resolve_combiner_value(
+                "combiner_min_sharpe",
+                "HK_DISCOVERY_COMBINER_MIN_SHARPE",
+                float,
+                combiner_defaults.min_sharpe,
+            ),
+            min_information_coefficient=resolve_combiner_value(
+                "combiner_min_ic",
+                "HK_DISCOVERY_COMBINER_MIN_IC",
+                float,
+                combiner_defaults.min_information_coefficient,
             ),
         )
 
@@ -73,7 +98,7 @@ class AppSettings:
             parallel_mode=parallel_mode,
             max_workers=max_workers,
             memory_limit_mb=memory_limit,
-            combiner_config=combiner_config,
+            combiner=combiner_config,
         )
 
 

--- a/application/container.py
+++ b/application/container.py
@@ -127,7 +127,7 @@ class ServiceContainer:
         return CombinerType(
             self.settings.symbol,
             phase1_results,
-            config=self.settings.combiner_config,
+            config=self.settings.combiner,
             data_loader=self.data_loader(),
         )
 

--- a/main.py
+++ b/main.py
@@ -55,26 +55,38 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--combiner-top-n",
         type=int,
-        default=combiner_defaults.top_n,
-        help="阶段2中纳入多因子组合评估的顶尖单因子数量",
+        default=None,
+        help=(
+            "阶段2中纳入多因子组合评估的顶尖单因子数量"
+            f"（默认: {combiner_defaults.top_n}）"
+        ),
     )
     parser.add_argument(
         "--combiner-max-factors",
         type=int,
-        default=combiner_defaults.max_factors,
-        help="组合生成时每个策略允许的最大因子个数",
+        default=None,
+        help=(
+            "组合生成时每个策略允许的最大因子个数"
+            f"（默认: {combiner_defaults.max_factors}）"
+        ),
     )
     parser.add_argument(
         "--combiner-min-sharpe",
         type=float,
-        default=combiner_defaults.min_sharpe,
-        help="筛选阶段2因子及策略时所需的最低夏普比率",
+        default=None,
+        help=(
+            "筛选阶段2因子及策略时所需的最低夏普比率"
+            f"（默认: {combiner_defaults.min_sharpe}）"
+        ),
     )
     parser.add_argument(
         "--combiner-min-ic",
         type=float,
-        default=combiner_defaults.min_information_coefficient,
-        help="筛选因子时所需的最小信息系数绝对值",
+        default=None,
+        help=(
+            "筛选因子时所需的最小信息系数绝对值"
+            f"（默认: {combiner_defaults.min_information_coefficient}）"
+        ),
     )
     return parser
 


### PR DESCRIPTION
## Summary
- add a combiner configuration dataclass field to `AppSettings`
- resolve combiner settings from CLI args with environment fallbacks before instantiating `CombinerConfig`
- surface combiner defaults in CLI help text and propagate the new field through the service container

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68cf0774aff8832aa6683ff0e9a29dd8