### PR TITLE
Update factor combiner to use AppSettings config

### DIFF
--- a/application/container.py
+++ b/application/container.py
@@ -125,8 +125,8 @@ class ServiceContainer:
         from phase2.combiner import MultiFactorCombiner as CombinerType
 
         return CombinerType(
-            self.settings.symbol,
-            phase1_results,
+            symbol=self.settings.symbol,
+            phase1_results=phase1_results,
             config=self.settings.combiner,
             data_loader=self.data_loader(),
         )


### PR DESCRIPTION
## Summary
- update `ServiceContainer.factor_combiner` to pass the AppSettings combiner configuration using keyword arguments when creating `MultiFactorCombiner`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68cf088792b4832abbcbbc0e001176d7