### PR TITLE
Add tests for combiner config overrides

### DIFF
--- a/tests/test_application_config.py
+++ b/tests/test_application_config.py
@@ -12,16 +12,43 @@ def test_app_settings_from_cli_args(tmp_path, monkeypatch):
         data_root=str(tmp_path),
         db_path=str(tmp_path / "db.sqlite"),
         log_level="DEBUG",
+        combiner_top_n=15,
+        combiner_max_factors=5,
+        combiner_min_sharpe=1.1,
+        combiner_min_ic=0.07,
     )
     settings = AppSettings.from_cli_args(args)
     assert settings.symbol == "0700.HK"
     assert settings.db_path == Path(tmp_path / "db.sqlite")
     assert settings.log_level == "DEBUG"
     assert settings.data_root == tmp_path
+    assert settings.combiner.top_n == 15
+    assert settings.combiner.max_factors == 5
+    assert settings.combiner.min_sharpe == 1.1
+    assert settings.combiner.min_information_coefficient == 0.07
 
 
 def test_app_settings_env_fallback(monkeypatch):
     monkeypatch.setenv("HK_DISCOVERY_DB", "/tmp/db.sqlite")
-    args = Namespace(symbol="0700.HK", phase="phase1", reset=False, data_root=None, db_path=None, log_level="INFO")
+    monkeypatch.setenv("HK_DISCOVERY_COMBINER_TOP_N", "12")
+    monkeypatch.setenv("HK_DISCOVERY_COMBINER_MAX_FACTORS", "4")
+    monkeypatch.setenv("HK_DISCOVERY_COMBINER_MIN_SHARPE", "0.9")
+    monkeypatch.setenv("HK_DISCOVERY_COMBINER_MIN_IC", "0.03")
+    args = Namespace(
+        symbol="0700.HK",
+        phase="phase1",
+        reset=False,
+        data_root=None,
+        db_path=None,
+        log_level="INFO",
+        combiner_top_n=None,
+        combiner_max_factors=None,
+        combiner_min_sharpe=None,
+        combiner_min_ic=None,
+    )
     settings = AppSettings.from_cli_args(args)
     assert settings.db_path == Path("/tmp/db.sqlite")
+    assert settings.combiner.top_n == 12
+    assert settings.combiner.max_factors == 4
+    assert settings.combiner.min_sharpe == 0.9
+    assert settings.combiner.min_information_coefficient == 0.03


### PR DESCRIPTION
## Summary
- extend AppSettings CLI/env tests to assert combiner config overrides
- add service container test verifying factor combiner receives the injected configuration

## Testing
- pytest tests/test_application_config.py tests/test_application_services.py

------
https://chatgpt.com/codex/tasks/task_e_68cf09903f78832ab0329b63cf8ca8bf