### PR TITLE
Add configurable factor monitoring and CLI tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ HK0920sen-code/
 
 2. **准备数据目录**
    - 将 `1m`、`2m`、`3m`、`5m`、`1d` 的 OHLCV Parquet/CSV 数据放在 `symbol/timeframe.parquet` 或 `timeframe/symbol.parquet` 结构下，二者皆受支持。
+   - 若使用 CSV，请包含可解析为时间索引的 `timestamp`（或 `datetime`/`date`）列，并提供 `open`、`high`、`low`、`close`、`volume` 字段。
    - 其余时间框架（10m、15m、30m、1h、2h、4h）由 `HistoricalDataLoader` 自动进行向量化重采样，无需额外文件。
 
 3. **运行命令行入口**

--- a/phase1/__init__.py
+++ b/phase1/__init__.py
@@ -1,13 +1,23 @@
 """Phase 1 factor exploration toolkit."""
 from .backtest_engine import SimpleBacktestEngine
-from .enhanced_backtest_engine import EnhancedBacktestEngine, create_enhanced_backtest_engine
-from .explorer import SingleFactorExplorer
+
+try:  # pragma: no cover - optional heavy dependencies
+    from .enhanced_backtest_engine import EnhancedBacktestEngine, create_enhanced_backtest_engine
+except ModuleNotFoundError:  # pragma: no cover
+    EnhancedBacktestEngine = None  # type: ignore[assignment]
+
+    def create_enhanced_backtest_engine(*_: object, **__: object):  # type: ignore[override]
+        raise ModuleNotFoundError("EnhancedBacktestEngine requires numpy/pandas")
+
+try:  # pragma: no cover - optional heavy dependencies
+    from .explorer import SingleFactorExplorer
+except ModuleNotFoundError:  # pragma: no cover
+    SingleFactorExplorer = None  # type: ignore[assignment]
+
 from .parallel_explorer import ParallelFactorExplorer
 
-__all__ = [
-    "SimpleBacktestEngine",
-    "EnhancedBacktestEngine",
-    "create_enhanced_backtest_engine",
-    "SingleFactorExplorer",
-    "ParallelFactorExplorer",
-]
+__all__ = ["SimpleBacktestEngine", "ParallelFactorExplorer"]
+if EnhancedBacktestEngine is not None:
+    __all__.extend(["EnhancedBacktestEngine", "create_enhanced_backtest_engine"])
+if SingleFactorExplorer is not None:
+    __all__.append("SingleFactorExplorer")

--- a/phase1/backtest_engine.py
+++ b/phase1/backtest_engine.py
@@ -27,10 +27,18 @@ class SimpleBacktestEngine:
         self.costs = HongKongTradingCosts()
 
     def backtest_factor(self, data: "pd.DataFrame", signals: "pd.Series") -> dict:
+        if not isinstance(signals, pd.Series):
+            signals = pd.Series(signals, index=data.index, dtype=float)
+        else:
+            if not signals.index.equals(data.index):
+                signals = signals.reindex(data.index)
+            signals = signals.astype(float)
+        signals = signals.fillna(0.0)
+
         close = data["close"].astype(float)
         returns = close.pct_change().fillna(0.0)
         future_returns = returns.shift(-1).fillna(0.0).to_numpy(dtype=float)
-        raw_signals = signals.fillna(0.0).to_numpy(dtype=float)
+        raw_signals = signals.to_numpy(dtype=float)
         positions = signals.shift(1).fillna(0.0) * self.allocation
         strategy_returns = (returns * positions).astype(float)
 

--- a/phase1/explorer.py
+++ b/phase1/explorer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
-from typing import Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 try:  # pragma: no cover
     import pandas as pd
@@ -12,7 +12,13 @@ except ModuleNotFoundError:  # pragma: no cover
 
 from config import DEFAULT_TIMEFRAMES
 from data_loader import HistoricalDataLoader
-from factors import FactorCalculator, all_factors
+try:  # pragma: no cover - optional heavy dependencies
+    from factors import FactorCalculator, all_factors
+except ModuleNotFoundError:  # pragma: no cover - allows lightweight tests
+    FactorCalculator = Any  # type: ignore[assignment]
+
+    def all_factors() -> list:
+        raise ModuleNotFoundError("numpy/pandas are required to enumerate the default factor set")
 from .backtest_engine import SimpleBacktestEngine
 
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,2 @@
+"""Helper scripts for interacting with the monitoring stack."""
+

--- a/scripts/factor_metrics.py
+++ b/scripts/factor_metrics.py
@@ -1,0 +1,130 @@
+"""CLI helper for inspecting factor metrics recorded by PerformanceMonitor."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List, Tuple
+
+from utils.monitoring import MetricCategory, get_performance_monitor
+
+
+def _normalise_metric_name(name: str) -> str:
+    if name.startswith("factor."):
+        return name
+    return f"factor.{name}"
+
+
+def _metric_basename(name: str) -> str:
+    return name.split(".", 1)[-1]
+
+
+def _group_by_factor(metrics: Iterable) -> Dict[str, Dict[str, object]]:
+    grouped: Dict[str, Dict[str, object]] = {}
+    for metric in metrics:
+        factor = metric.tags.get("factor_name", "unknown") if metric.tags else "unknown"
+        entry = grouped.setdefault(
+            factor,
+            {"samples": 0, "latest": {}, "timestamps": []},
+        )
+        entry["samples"] = int(entry["samples"]) + 1
+        entry["timestamps"].append(metric.timestamp)
+
+        base_name = _metric_basename(metric.name)
+        latest = entry["latest"]
+        stored = latest.get(base_name)
+        if not stored or stored[0] < metric.timestamp:
+            latest[base_name] = (metric.timestamp, metric.value)
+
+    return grouped
+
+
+def _build_scoreboard(
+    grouped: Dict[str, Dict[str, object]],
+    metric_name: str,
+) -> List[Tuple[str, float]]:
+    baseline = _metric_basename(metric_name)
+    scores: List[Tuple[str, float]] = []
+    for factor, payload in grouped.items():
+        latest = payload["latest"]  # type: ignore[assignment]
+        if baseline in latest:
+            scores.append((factor, float(latest[baseline][1])))
+    return sorted(scores, key=lambda item: item[1], reverse=True)
+
+
+def _format_factor_line(factor: str, payload: Dict[str, object]) -> str:
+    samples = payload["samples"]
+    latest = payload["latest"]  # type: ignore[assignment]
+    metrics_repr = ", ".join(
+        f"{name}={value[1]:.4f}" if isinstance(value[1], float) else f"{name}={value[1]}"
+        for name, value in sorted(latest.items())
+    )
+    return f"- {factor} ({samples} samples): {metrics_repr}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Inspect factor metrics recorded by the monitoring stack")
+    parser.add_argument("--hours", type=int, default=24, help="Time window to inspect (default: 24 hours)")
+    parser.add_argument("--metric", help="Filter to a specific metric name (e.g. sharpe_ratio)")
+    parser.add_argument("--top", type=int, help="Only display the top N factors when --metric is provided")
+    parser.add_argument(
+        "--export",
+        choices=["json", "csv"],
+        help="Optional export format for the same metric window",
+    )
+    parser.add_argument(
+        "--export-dir",
+        default="exports",
+        help="Directory for exported metric dumps (default: exports)",
+    )
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    monitor = get_performance_monitor()
+    current_time = datetime.now(timezone.utc).replace(tzinfo=None)
+    start_time = current_time - timedelta(hours=args.hours)
+    metrics = monitor.get_metrics(
+        start_time=start_time,
+        categories=[MetricCategory.FACTOR_COMPUTATION],
+    )
+
+    if args.metric:
+        target = _normalise_metric_name(args.metric)
+        metrics = [metric for metric in metrics if metric.name == target]
+    grouped = _group_by_factor(metrics)
+
+    print(f"=== Factor metrics in the last {args.hours}h ===")
+    if not grouped:
+        print("No factor metrics were recorded in the selected window.")
+    else:
+        for factor, payload in sorted(grouped.items()):
+            print(_format_factor_line(factor, payload))
+
+    if args.metric and grouped:
+        scoreboard = _build_scoreboard(grouped, _normalise_metric_name(args.metric))
+        if args.top is not None:
+            scoreboard = scoreboard[: args.top]
+        print("\n=== Leaderboard ===")
+        if not scoreboard:
+            print(f"No factors reported the metric '{args.metric}'.")
+        else:
+            for rank, (factor, score) in enumerate(scoreboard, start=1):
+                print(f"{rank:>2}. {factor}: {score:.4f}")
+
+    if args.export:
+        export_path = monitor.export_metrics(
+            format_type=args.export,
+            export_dir=args.export_dir,
+            start_time=start_time,
+            categories=[MetricCategory.FACTOR_COMPUTATION],
+        )
+        print(f"\nMetrics exported to {export_path}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -59,3 +59,16 @@ def test_backtest_engine_applies_transaction_costs(monkeypatch):
     non_zero = difference[np.abs(difference) > 0]
     assert non_zero.size == with_cost["trades_count"]
     assert np.allclose(non_zero, expected_drag)
+
+
+def test_backtest_engine_aligns_numpy_signals(monkeypatch):
+    data, signals = _build_sample_data()
+    engine = SimpleBacktestEngine("0700.HK", allocation=0.5)
+    monkeypatch.setattr(engine.costs, "calculate_total_cost", lambda _: 0.0)
+
+    numpy_signals = signals.to_numpy(dtype=float)
+    result = engine.backtest_factor(data, numpy_signals)
+
+    assert isinstance(result["returns"], pd.Series)
+    assert list(result["returns"].index) == list(data.index)
+    assert isinstance(result["equity_curve"], pd.Series)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -61,7 +61,20 @@ def test_load_raw_supports_timeframe_first_layout(tmp_path, monkeypatch):
     loader = HistoricalDataLoader(data_root=tmp_path)
     loaded = loader.load("0700.HK", "1m")
 
-    pd_testing.assert_frame_equal(loaded, dataframe)
+    pd_testing.assert_frame_equal(loaded, dataframe, check_freq=False)
+
+
+def test_load_raw_supports_csv_files(tmp_path):
+    dataframe = _sample_frame()
+    csv_dir = tmp_path / "raw_data" / "1m"
+    csv_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = csv_dir / "0700.HK.csv"
+    dataframe.reset_index().rename(columns={"index": "timestamp"}).to_csv(csv_path, index=False)
+
+    loader = HistoricalDataLoader(data_root=tmp_path)
+    loaded = loader.load("0700.HK", "1m")
+
+    pd_testing.assert_frame_equal(loaded, dataframe, check_freq=False)
 
 
 def test_optimized_loader_uses_disk_cache(tmp_path):

--- a/tests/test_factor_monitoring.py
+++ b/tests/test_factor_monitoring.py
@@ -1,0 +1,113 @@
+"""Tests for factor-focused monitoring helpers."""
+from __future__ import annotations
+
+from scripts import factor_metrics
+from utils.monitoring import (
+    AlertSeverity,
+    FactorAlertDefinition,
+    FactorMetricTemplate,
+    MetricCategory,
+    MonitorConfig,
+    PerformanceMonitor,
+    get_performance_monitor,
+    stop_global_monitoring,
+)
+
+
+def _monitor_config(tmp_path):
+    log_dir = tmp_path / "logs"
+    db_path = tmp_path / "monitor.db"
+    return MonitorConfig(
+        enabled=False,
+        log_dir=str(log_dir),
+        database_path=str(db_path),
+        factor_metrics=[
+            FactorMetricTemplate(
+                name="sharpe_ratio",
+                unit=None,
+                default_tags={"horizon": "daily"},
+                metadata={"template": "baseline"},
+            ),
+            FactorMetricTemplate(name="max_drawdown"),
+        ],
+    )
+
+
+def test_record_factor_metrics_adds_tags_and_category(tmp_path):
+    config = _monitor_config(tmp_path)
+    monitor = PerformanceMonitor(config)
+
+    monitor.record_factor_metrics(
+        "alpha",
+        {"sharpe_ratio": 1.25, "max_drawdown": 0.18},
+        extra_tags={"timeframe": "1d"},
+        metadata={"window": "2023-01"},
+    )
+
+    sharpe_series = monitor.metrics_history["factor.sharpe_ratio"]
+    latest = sharpe_series[-1]
+    assert latest.category == MetricCategory.FACTOR_COMPUTATION
+    assert latest.tags["factor_name"] == "alpha"
+    assert latest.tags["timeframe"] == "1d"
+    assert latest.tags["horizon"] == "daily"
+    assert latest.metadata == {"template": "baseline", "window": "2023-01"}
+
+    monitor.stop()
+
+
+def test_factor_alerts_trigger_and_resolve(tmp_path):
+    config = MonitorConfig(
+        enabled=False,
+        log_dir=str(tmp_path / "logs"),
+        database_path=str(tmp_path / "monitor.db"),
+        factor_metrics=[FactorMetricTemplate(name="sharpe_ratio")],
+        factor_alerts=[
+            FactorAlertDefinition(
+                name="low_sharpe",
+                metric="sharpe_ratio",
+                condition="<",
+                threshold=0.5,
+                severity=AlertSeverity.WARNING,
+                message_template="Sharpe below 0.5 for {factor_name}: {value:.2f}",
+            )
+        ],
+    )
+    monitor = PerformanceMonitor(config)
+
+    monitor.record_factor_metrics("momentum", {"sharpe_ratio": 0.4})
+    assert monitor.active_alerts, "Expected alert to trigger for low sharpe ratio"
+    active_alert = next(iter(monitor.active_alerts.values()))
+    assert active_alert.rule_name == "low_sharpe"
+    assert "momentum" in active_alert.message
+    assert active_alert.tags == {"factor_name": "momentum"}
+
+    monitor.record_factor_metrics("momentum", {"sharpe_ratio": 0.8})
+    assert not monitor.active_alerts, "Alert should resolve once metric recovers"
+
+    monitor.stop()
+
+
+def test_factor_metrics_cli_reports_grouped_values(tmp_path, capsys):
+    stop_global_monitoring()
+    config = MonitorConfig(
+        enabled=False,
+        log_dir=str(tmp_path / "logs"),
+        database_path=str(tmp_path / "monitor.db"),
+        factor_metrics=[
+            FactorMetricTemplate(name="sharpe_ratio"),
+            FactorMetricTemplate(name="max_drawdown"),
+        ],
+    )
+    monitor = get_performance_monitor(config)
+
+    monitor.record_factor_metrics("alpha", {"sharpe_ratio": 1.2, "max_drawdown": 0.1})
+    monitor.record_factor_metrics("beta", {"sharpe_ratio": 0.9})
+
+    exit_code = factor_metrics.main(["--hours", "1", "--metric", "sharpe_ratio", "--top", "1"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "alpha" in captured.out
+    assert "Leaderboard" in captured.out
+
+    stop_global_monitoring()

--- a/utils/performance_metrics.py
+++ b/utils/performance_metrics.py
@@ -1,27 +1,42 @@
-"""Performance metric helpers for the discovery workflow."""
+"""Collection of helpers to compute basic portfolio statistics."""
 from __future__ import annotations
 
-import numpy as np
+from typing import Sequence
+
+try:  # pragma: no cover - optional dependency guard
+    import numpy as _np  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - allows lightweight test environments
+    _np = None  # type: ignore[assignment]
 
 
 class PerformanceMetrics:
-    """Collection of static helpers to compute portfolio statistics."""
+    """Namespace of statistical helpers used by backtests and combiners."""
 
     @staticmethod
-    def calculate_sharpe_ratio(returns: np.ndarray, risk_free_rate: float = 0.02) -> float:
-        if returns.size == 0:
+    def _require_numpy():  # type: ignore[return-any]
+        if _np is None:
+            raise ModuleNotFoundError("numpy is required for performance metric calculations")
+        return _np
+
+    @staticmethod
+    def calculate_sharpe_ratio(returns: Sequence[float], risk_free_rate: float = 0.02) -> float:
+        np = PerformanceMetrics._require_numpy()
+        array = np.asarray(returns, dtype=float)
+        if array.size == 0:
             return 0.0
-        excess_returns = returns - risk_free_rate / 252.0
+        excess_returns = array - risk_free_rate / 252.0
         std = np.std(excess_returns, ddof=1)
         if std == 0 or np.isnan(std):
             return 0.0
         return float(np.sqrt(252) * np.mean(excess_returns) / std)
 
     @staticmethod
-    def calculate_stability(returns: np.ndarray) -> float:
-        if returns.size <= 1:
+    def calculate_stability(returns: Sequence[float]) -> float:
+        np = PerformanceMetrics._require_numpy()
+        array = np.asarray(returns, dtype=float)
+        if array.size <= 1:
             return 0.0
-        cumulative_returns = np.cumprod(1 + returns)
+        cumulative_returns = np.cumprod(1 + array)
         x = np.arange(len(cumulative_returns))
         x_mean = x.mean()
         y_mean = cumulative_returns.mean()
@@ -34,34 +49,41 @@ class PerformanceMetrics:
         return float(r_value ** 2)
 
     @staticmethod
-    def calculate_profit_factor(gains: np.ndarray, losses: np.ndarray) -> float:
-        total_gains = gains.sum()
-        total_losses = losses.sum()
+    def calculate_profit_factor(gains: Sequence[float], losses: Sequence[float]) -> float:
+        np = PerformanceMetrics._require_numpy()
+        gains_array = np.asarray(gains, dtype=float)
+        losses_array = np.asarray(losses, dtype=float)
+        total_gains = gains_array.sum()
+        total_losses = losses_array.sum()
         if np.isclose(total_losses, 0):
             return float("inf") if total_gains > 0 else 0.0
         return float(total_gains / abs(total_losses))
 
     @staticmethod
-    def calculate_max_drawdown(equity_curve: np.ndarray) -> float:
-        if equity_curve.size == 0:
+    def calculate_max_drawdown(equity_curve: Sequence[float]) -> float:
+        np = PerformanceMetrics._require_numpy()
+        array = np.asarray(equity_curve, dtype=float)
+        if array.size == 0:
             return 0.0
-        running_max = np.maximum.accumulate(equity_curve)
-        drawdown = (running_max - equity_curve) / running_max
+        running_max = np.maximum.accumulate(array)
+        drawdown = (running_max - array) / running_max
         return float(np.nanmax(drawdown))
 
     @staticmethod
-    def calculate_information_coefficient(signals: np.ndarray, future_returns: np.ndarray) -> float:
-        """Pearson correlation between signals and subsequent period returns."""
+    def calculate_information_coefficient(signals: Sequence[float], future_returns: Sequence[float]) -> float:
+        np = PerformanceMetrics._require_numpy()
+        signal_array = np.asarray(signals, dtype=float)
+        return_array = np.asarray(future_returns, dtype=float)
 
-        if signals.size == 0 or future_returns.size == 0:
+        if signal_array.size == 0 or return_array.size == 0:
             return 0.0
 
-        limit = min(signals.size, future_returns.size)
+        limit = min(signal_array.size, return_array.size)
         if limit == 0:
             return 0.0
 
-        aligned_signals = np.asarray(signals[:limit], dtype=float)
-        aligned_returns = np.asarray(future_returns[:limit], dtype=float)
+        aligned_signals = signal_array[:limit]
+        aligned_returns = return_array[:limit]
         mask = ~np.isnan(aligned_signals) & ~np.isnan(aligned_returns)
         if not np.any(mask):
             return 0.0
@@ -71,7 +93,6 @@ class PerformanceMetrics:
         if valid_signals.size == 0 or valid_returns.size == 0:
             return 0.0
 
-        # Skip constant signals to avoid numpy warnings and meaningless correlations.
         if np.nanstd(valid_signals) == 0 or np.nanstd(valid_returns) == 0:
             return 0.0
 
@@ -79,3 +100,6 @@ class PerformanceMetrics:
         if np.isnan(coefficient):
             return 0.0
         return float(coefficient)
+
+
+__all__ = ["PerformanceMetrics"]


### PR DESCRIPTION
## Summary
- extend `PerformanceMonitor` with factor metric templates, alert registration, optional psutil fallback, and a convenience API for recording tagged factor metrics
- add a lightweight `scripts/factor_metrics.py` CLI to review aggregated factor metrics and optionally export the data window
- document the factor workflow, relax phase-one imports for missing heavy deps, and cover the new behaviour with focused pytest scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf00c4b6cc832aa7739b8de1299864