### PR TITLE
Add CLI overrides for combiner thresholds

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--combiner-top-n",
+        dest="combiner_top_n",
         type=int,
         default=None,
         help=(
@@ -63,6 +64,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--combiner-max-factors",
+        dest="combiner_max_factors",
         type=int,
         default=None,
         help=(
@@ -72,6 +74,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--combiner-min-sharpe",
+        dest="combiner_min_sharpe",
         type=float,
         default=None,
         help=(
@@ -81,6 +84,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--combiner-min-ic",
+        dest="combiner_min_ic",
         type=float,
         default=None,
         help=(


### PR DESCRIPTION
## Summary
- register the combiner CLI parameters with explicit destinations so they are retained on the parsed namespace
- keep the options typed and documented with default values sourced from ``CombinerConfig``

## Testing
- pytest tests/test_application_config.py

------
https://chatgpt.com/codex/tasks/task_e_68cf1034528c832aa34bb36498056f1e