### PR TITLE
Add coverage for combiner configuration propagation

### DIFF
--- a/tests/test_application_config.py
+++ b/tests/test_application_config.py
@@ -52,3 +52,30 @@ def test_app_settings_env_fallback(monkeypatch):
     assert settings.combiner.max_factors == 4
     assert settings.combiner.min_sharpe == 0.9
     assert settings.combiner.min_information_coefficient == 0.03
+
+
+def test_app_settings_cli_overrides_combiner_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HK_DISCOVERY_COMBINER_TOP_N", "9")
+    monkeypatch.setenv("HK_DISCOVERY_COMBINER_MAX_FACTORS", "3")
+    monkeypatch.setenv("HK_DISCOVERY_COMBINER_MIN_SHARPE", "0.5")
+    monkeypatch.setenv("HK_DISCOVERY_COMBINER_MIN_IC", "0.02")
+
+    args = Namespace(
+        symbol="0700.HK",
+        phase="phase2",
+        reset=False,
+        data_root=str(tmp_path / "data"),
+        db_path=str(tmp_path / "db.sqlite"),
+        log_level="WARNING",
+        combiner_top_n=25,
+        combiner_max_factors=6,
+        combiner_min_sharpe=1.2,
+        combiner_min_ic=0.11,
+    )
+
+    settings = AppSettings.from_cli_args(args)
+
+    assert settings.combiner.top_n == 25
+    assert settings.combiner.max_factors == 6
+    assert settings.combiner.min_sharpe == 1.2
+    assert settings.combiner.min_information_coefficient == 0.11


### PR DESCRIPTION
## Summary
- add a test confirming CLI overrides for combiner-related AppSettings fields, even when environment variables are set
- add a ServiceContainer test capturing the configuration passed to MultiFactorCombiner when settings come from CLI arguments

## Testing
- pytest tests/test_application_config.py tests/test_application_services.py

------
https://chatgpt.com/codex/tasks/task_e_68cf6ab69284832a9f82abff6b5b6e5e