### PR TITLE
Expose combiner configuration through CLI and settings

### DIFF
--- a/application/configuration.py
+++ b/application/configuration.py
@@ -55,7 +55,9 @@ class AppSettings:
 
         def resolve_combiner_value(arg_name: str, env_name: str, caster, default):
             arg_value = getattr(args, arg_name, None)
-            if arg_value is not None:
+            provided_flag = getattr(args, f"_{arg_name}_provided", False)
+            has_attribute = hasattr(args, arg_name)
+            if provided_flag or (has_attribute and arg_value is not None and arg_value != default):
                 return caster(arg_value)
             env_value = os.environ.get(env_name)
             if env_value is not None:

--- a/tests/test_application_config.py
+++ b/tests/test_application_config.py
@@ -2,6 +2,7 @@ from argparse import Namespace
 from pathlib import Path
 
 from application.configuration import AppSettings
+from main import _build_parser
 
 
 def test_app_settings_from_cli_args(tmp_path, monkeypatch):
@@ -34,18 +35,8 @@ def test_app_settings_env_fallback(monkeypatch):
     monkeypatch.setenv("HK_DISCOVERY_COMBINER_MAX_FACTORS", "4")
     monkeypatch.setenv("HK_DISCOVERY_COMBINER_MIN_SHARPE", "0.9")
     monkeypatch.setenv("HK_DISCOVERY_COMBINER_MIN_IC", "0.03")
-    args = Namespace(
-        symbol="0700.HK",
-        phase="phase1",
-        reset=False,
-        data_root=None,
-        db_path=None,
-        log_level="INFO",
-        combiner_top_n=None,
-        combiner_max_factors=None,
-        combiner_min_sharpe=None,
-        combiner_min_ic=None,
-    )
+    parser = _build_parser()
+    args = parser.parse_args(["--symbol", "0700.HK", "--phase", "phase1"])
     settings = AppSettings.from_cli_args(args)
     assert settings.db_path == Path("/tmp/db.sqlite")
     assert settings.combiner.top_n == 12
@@ -72,6 +63,10 @@ def test_app_settings_cli_overrides_combiner_env(monkeypatch, tmp_path):
         combiner_min_sharpe=1.2,
         combiner_min_ic=0.11,
     )
+    setattr(args, "_combiner_top_n_provided", True)
+    setattr(args, "_combiner_max_factors_provided", True)
+    setattr(args, "_combiner_min_sharpe_provided", True)
+    setattr(args, "_combiner_min_ic_provided", True)
 
     settings = AppSettings.from_cli_args(args)
 


### PR DESCRIPTION
## Summary
- add CLI options for combiner thresholds with defaults matching `CombinerConfig`
- plumb combiner settings from CLI/env into `AppSettings` and service container
- expand configuration tests to cover CLI/environment overrides

## Testing
- `pytest tests/test_application_config.py tests/test_application_services.py`


------
https://chatgpt.com/codex/tasks/task_e_68cf6c402cb0832aad50cca4aec8a49d