### PR TITLE
Simplify combiner dependencies

### DIFF
--- a/application/container.py
+++ b/application/container.py
@@ -132,7 +132,6 @@ class ServiceContainer:
             symbol=self.settings.symbol,
             phase1_results=phase1_results,
             config=combiner_config,
-            data_loader=self.data_loader(),
         )
 
     def logger(self):

--- a/phase2/combiner.py
+++ b/phase2/combiner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from itertools import combinations
 from math import comb
-from typing import Dict, Iterable, List, Mapping, Optional, Sequence
+from typing import Dict, List, Mapping, Optional, Sequence
 
 import numpy as np
 
@@ -29,14 +29,10 @@ class MultiFactorCombiner:
         phase1_results: Mapping[str, Mapping[str, object]],
         *,
         config: CombinerConfig | None = None,
-        timeframes: Optional[Iterable[str]] = None,
-        data_loader=None,
     ) -> None:
         self.symbol = symbol
         self.phase1_results = phase1_results
         self.config = config or CombinerConfig()
-        self.timeframes = list(timeframes) if timeframes is not None else []
-        self.data_loader = data_loader
         self._last_selected_factors: List[Mapping[str, object]] = []
 
     def select_top_factors(self, top_n: Optional[int] = None) -> List[Mapping[str, object]]:

--- a/tests/test_application_services.py
+++ b/tests/test_application_services.py
@@ -120,11 +120,10 @@ def test_service_container_passes_combiner_config(monkeypatch):
     captured = {}
 
     class CaptureCombiner:
-        def __init__(self, *, symbol, phase1_results, config, data_loader):
+        def __init__(self, *, symbol, phase1_results, config):
             captured["symbol"] = symbol
             captured["phase1_results"] = phase1_results
             captured["config"] = config
-            captured["data_loader"] = data_loader
             captured["instance"] = self
 
     combiner_module = types.ModuleType("phase2.combiner")
@@ -144,8 +143,10 @@ def test_service_container_passes_combiner_config(monkeypatch):
     )
     container = ServiceContainer(settings)
 
-    dummy_loader = object()
-    monkeypatch.setattr(container, "data_loader", lambda: dummy_loader)
+    def fail_data_loader():
+        raise AssertionError("data_loader should not be used when initialising combiner")
+
+    monkeypatch.setattr(container, "data_loader", fail_data_loader)
 
     phase1_results = {"demo": {"sharpe_ratio": 1.0}}
     combiner = container.factor_combiner(phase1_results)
@@ -154,7 +155,6 @@ def test_service_container_passes_combiner_config(monkeypatch):
     assert captured["symbol"] == "0700.HK"
     assert captured["phase1_results"] is phase1_results
     assert captured["config"] == settings.combiner
-    assert captured["data_loader"] is dummy_loader
 
 
 def test_service_container_uses_appsettings_combiner(monkeypatch, tmp_path):
@@ -164,11 +164,10 @@ def test_service_container_uses_appsettings_combiner(monkeypatch, tmp_path):
     captured = {}
 
     class CaptureCombiner:
-        def __init__(self, *, symbol, phase1_results, config, data_loader):
+        def __init__(self, *, symbol, phase1_results, config):
             captured["symbol"] = symbol
             captured["phase1_results"] = phase1_results
             captured["config"] = config
-            captured["data_loader"] = data_loader
             captured["instance"] = self
 
     combiner_module = types.ModuleType("phase2.combiner")
@@ -193,8 +192,10 @@ def test_service_container_uses_appsettings_combiner(monkeypatch, tmp_path):
     settings = AppSettings.from_cli_args(args)
     container = ServiceContainer(settings)
 
-    dummy_loader = object()
-    monkeypatch.setattr(container, "data_loader", lambda: dummy_loader)
+    def fail_data_loader():
+        raise AssertionError("data_loader should not be used when initialising combiner")
+
+    monkeypatch.setattr(container, "data_loader", fail_data_loader)
 
     phase1_results = {"demo": {"sharpe_ratio": 1.0}}
     combiner = container.factor_combiner(phase1_results)
@@ -214,11 +215,10 @@ def test_service_container_supports_combiner_config_alias(monkeypatch):
     captured = {}
 
     class CaptureCombiner:
-        def __init__(self, *, symbol, phase1_results, config, data_loader):
+        def __init__(self, *, symbol, phase1_results, config):
             captured["symbol"] = symbol
             captured["phase1_results"] = phase1_results
             captured["config"] = config
-            captured["data_loader"] = data_loader
             captured["instance"] = self
 
     combiner_module = types.ModuleType("phase2.combiner")
@@ -250,8 +250,10 @@ def test_service_container_supports_combiner_config_alias(monkeypatch):
 
     container = ServiceContainer(LegacySettings())
 
-    dummy_loader = object()
-    monkeypatch.setattr(container, "data_loader", lambda: dummy_loader)
+    def fail_data_loader():
+        raise AssertionError("data_loader should not be used when initialising combiner")
+
+    monkeypatch.setattr(container, "data_loader", fail_data_loader)
 
     phase1_results = {"demo": {"sharpe_ratio": 1.0}}
     combiner = container.factor_combiner(phase1_results)
@@ -260,4 +262,3 @@ def test_service_container_supports_combiner_config_alias(monkeypatch):
     assert captured["symbol"] == "0700.HK"
     assert captured["phase1_results"] is phase1_results
     assert captured["config"] == container.settings.combiner_config
-    assert captured["data_loader"] is dummy_loader


### PR DESCRIPTION
## Summary
- remove unused timeframe/data_loader dependencies from `MultiFactorCombiner`
- stop `ServiceContainer.factor_combiner` from instantiating the combiner with a data loader
- update service container tests to match the simplified signature and assert the loader is not touched

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf6fdd3020832a8b29f7a54a222242