### PR TITLE
Add CLI-configurable performance monitoring integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ HK0920sen-code/
    - `--phase phase1|phase2|both` 控制执行阶段，默认 `both`。
    - `--reset` 会清空 SQLite 数据库重新探索。
    - `--log-level` 指定日志级别；亦可通过环境变量 `HK_DISCOVERY_LOG_LEVEL` 配置。
+   - `--enable-monitoring` 可启用性能监控，`--monitor-log-dir` 与 `--monitor-db-path` 用于覆盖监控日志/数据库目录；同名环境变量 `HK_DISCOVERY_MONITORING_ENABLED`、`HK_DISCOVERY_MONITOR_LOG_DIR`、`HK_DISCOVERY_MONITOR_DB_PATH` 亦可独立配置。
    - `HK_DISCOVERY_DB`、`HK_DISCOVERY_CACHE_TTL` 等环境变量可覆盖数据库位置与缓存策略。
 
 ## 编程接口

--- a/application/container.py
+++ b/application/container.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, Type, TypeVar
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Type, TypeVar
 
 from database import DatabaseManager
 from utils.cache import InMemoryCache
 from utils.logging import get_logger
+from utils.monitoring import PerformanceMonitor
 from .configuration import AppSettings
 
 if TYPE_CHECKING:  # pragma: no cover - type hinting only
@@ -157,6 +158,16 @@ class ServiceContainer:
 
     def logger(self):
         return self._logger
+
+    def performance_monitor(self) -> Optional[PerformanceMonitor]:
+        monitoring_config = getattr(self.settings, "monitoring", None)
+        if not monitoring_config:
+            return None
+
+        def factory() -> PerformanceMonitor:
+            return PerformanceMonitor(monitoring_config)
+
+        return self.resolve(PerformanceMonitor, factory)
 
 
 __all__ = ["ServiceContainer"]

--- a/application/services.py
+++ b/application/services.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 
 from database import FactorResult
 from .configuration import AppSettings
 from .container import ServiceContainer
+from utils.monitoring import MetricCategory, MetricType, PerformanceMonitor
 
 
 @dataclass
@@ -24,6 +25,12 @@ class DiscoveryOrchestrator:
         self.settings = settings
         self.container = container
         self.logger = container.logger()
+        monitor_factory = getattr(container, "performance_monitor", None)
+        self.monitor: Optional[PerformanceMonitor]
+        if callable(monitor_factory):
+            self.monitor = monitor_factory()
+        else:
+            self.monitor = None
 
     # ------------------------------------------------------------------
     async def run_async(self) -> PhaseResult:
@@ -34,35 +41,96 @@ class DiscoveryOrchestrator:
         db = self.container.database()
 
         phase1_results: Dict[str, Dict[str, object]] = {}
-        if self.settings.phase in {"phase1", "both"}:
-            self.logger.info("开始阶段1: 单因子探索")
-            explorer = self.container.factor_explorer()
-            phase1_results = await explorer.explore_all_factors_async(
-                batch_size=self.settings.async_batch_size
-            )
-            timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-            for row in phase1_results.values():
-                row["exploration_date"] = timestamp
-            db.save_exploration_results(phase1_results.values())
-            self.logger.info("完成 %s 个因子探索", len(phase1_results))
+        phase1_executed = False
+
+        async def _run_phase1() -> None:
+            nonlocal phase1_results, phase1_executed
+            if self.settings.phase in {"phase1", "both"}:
+                phase1_executed = True
+                self.logger.info("开始阶段1: 单因子探索")
+                explorer = self.container.factor_explorer()
+                phase1_results = await explorer.explore_all_factors_async(
+                    batch_size=self.settings.async_batch_size
+                )
+                timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+                for row in phase1_results.values():
+                    row["exploration_date"] = timestamp
+                db.save_exploration_results(phase1_results.values())
+                self.logger.info("完成 %s 个因子探索", len(phase1_results))
+            else:
+                stored = db.load_exploration_results(self.settings.symbol)
+                if not stored:
+                    raise RuntimeError("没有阶段1结果，请先运行 phase1")
+                phase1_results = await self._rehydrate_phase1(stored)
+
+        monitor_tags = {
+            "symbol": self.settings.symbol,
+            "parallel_mode": self.settings.parallel_mode,
+        }
+        if self.monitor:
+            self.monitor.operation_timers.setdefault("discovery_phase1_total", 0.0)
+            with self.monitor.measure_operation(
+                "discovery_phase1", tags={**monitor_tags, "phase": "phase1"}
+            ):
+                await _run_phase1()
         else:
-            stored = db.load_exploration_results(self.settings.symbol)
-            if not stored:
-                raise RuntimeError("没有阶段1结果，请先运行 phase1")
-            phase1_results = await self._rehydrate_phase1(stored)
+            await _run_phase1()
+
+        if self.monitor:
+            self.monitor.record_metric(
+                "discovery_phase1_result_count",
+                float(len(phase1_results)),
+                metric_type=MetricType.GAUGE,
+                category=MetricCategory.OPERATION,
+                tags={**monitor_tags, "phase": "phase1"},
+                metadata={"executed": phase1_executed},
+            )
 
         strategies: List[Dict[str, object]] = []
+        phase2_executed = False
         if self.settings.phase in {"phase2", "both"}:
-            self.logger.info("开始阶段2: 多因子组合")
-            combiner = self.container.factor_combiner(phase1_results)
-            strategies = combiner.discover_strategies()
-            timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-            for strategy in strategies:
-                strategy["creation_date"] = timestamp
-            db.save_combination_strategies(strategies)
-            self.logger.info("完成阶段2组合，发现 %s 个策略", len(strategies))
+            phase2_executed = True
+            if self.monitor:
+                self.monitor.operation_timers.setdefault("discovery_phase2_total", 0.0)
+                with self.monitor.measure_operation(
+                    "discovery_phase2", tags={**monitor_tags, "phase": "phase2"}
+                ):
+                    strategies = self._run_phase2(db, phase1_results)
+            else:
+                strategies = self._run_phase2(db, phase1_results)
+        elif self.monitor:
+            # record zero strategies for visibility when 阶段2 未执行
+            self.monitor.record_metric(
+                "discovery_phase2_result_count",
+                0.0,
+                metric_type=MetricType.GAUGE,
+                category=MetricCategory.OPERATION,
+                tags={**monitor_tags, "phase": "phase2"},
+                metadata={"executed": False},
+            )
+
+        if self.monitor and phase2_executed:
+            self.monitor.record_metric(
+                "discovery_phase2_result_count",
+                float(len(strategies)),
+                metric_type=MetricType.GAUGE,
+                category=MetricCategory.OPERATION,
+                tags={**monitor_tags, "phase": "phase2"},
+                metadata={"executed": True},
+            )
 
         return PhaseResult(phase1=phase1_results, strategies=strategies)
+
+    def _run_phase2(self, db, phase1_results: Dict[str, Dict[str, object]]) -> List[Dict[str, object]]:
+        self.logger.info("开始阶段2: 多因子组合")
+        combiner = self.container.factor_combiner(phase1_results)
+        strategies = combiner.discover_strategies()
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        for strategy in strategies:
+            strategy["creation_date"] = timestamp
+        db.save_combination_strategies(strategies)
+        self.logger.info("完成阶段2组合，发现 %s 个策略", len(strategies))
+        return strategies
 
     async def _rehydrate_phase1(self, rows: Iterable[FactorResult]) -> Dict[str, Dict[str, object]]:
         explorer = self.container.factor_explorer()

--- a/docs/MONITORING_OVERVIEW.md
+++ b/docs/MONITORING_OVERVIEW.md
@@ -18,6 +18,23 @@ monitor = PerformanceMonitor(config)
 - Directories referenced in the config are created automatically.
 - The monitor collects system snapshots (CPU, memory, disk, network) and stores them in SQLite + JSON files.
 
+## Enabling Monitoring in the CLI Workflow
+
+The discovery CLI can now bootstrap a `PerformanceMonitor` directly via command-line flags or environment variables. Pass `--enable-monitoring` when invoking `python -m main` to turn on background collection:
+
+```bash
+python -m main \
+    --symbol 0700.HK \
+    --phase both \
+    --enable-monitoring \
+    --monitor-log-dir runtime/logs \
+    --monitor-db-path runtime/monitoring/performance.db
+```
+
+- `--monitor-log-dir` and `--monitor-db-path` override the log and SQLite locations respectively.
+- The same values can be supplied via environment variables `HK_DISCOVERY_MONITORING_ENABLED`, `HK_DISCOVERY_MONITOR_LOG_DIR` and `HK_DISCOVERY_MONITOR_DB_PATH`.
+- When enabled, `DiscoveryOrchestrator` wraps phase 1 and phase 2 execution with `measure_operation`, generating duration/error counters (`discovery_phase1_duration`, `discovery_phase2_duration`, etc.) and summary gauges (`discovery_phase1_result_count`, `discovery_phase2_result_count`).
+
 ## Recording Custom Metrics
 
 ```python
@@ -147,5 +164,5 @@ factor KPIs:
 ## Integration Tips
 
 - Initialise a single `PerformanceMonitor` and reuse it through dependency injection (`ServiceContainer.logger()` is a good reference pattern).
-- Use environment variables (`HK_DISCOVERY_MONITOR_DIR`, etc.) to override defaults for staging/production deployments.
+- Use the `HK_DISCOVERY_MONITORING_ENABLED`, `HK_DISCOVERY_MONITOR_LOG_DIR` and `HK_DISCOVERY_MONITOR_DB_PATH` environment variables to override defaults for staging/production deployments.
 - Combine metrics with the structured logging helpers in `utils.enhanced_logging` to produce consistent audits and performance dashboards.

--- a/main.py
+++ b/main.py
@@ -63,6 +63,19 @@ def _build_parser() -> argparse.ArgumentParser:
         help="日志级别 (DEBUG/INFO/WARNING/ERROR)",
     )
     parser.add_argument(
+        "--enable-monitoring",
+        action="store_true",
+        help="启用性能监控（也可通过环境变量 HK_DISCOVERY_MONITORING_ENABLED 控制）",
+    )
+    parser.add_argument(
+        "--monitor-log-dir",
+        help="性能监控日志目录（默认: logs/performance）",
+    )
+    parser.add_argument(
+        "--monitor-db-path",
+        help="性能监控 SQLite 数据库路径（默认: monitoring/performance.db）",
+    )
+    parser.add_argument(
         "--parallel-mode",
         choices=["off", "process"],
         default="off",


### PR DESCRIPTION
## Summary
- add monitoring settings to `AppSettings` and expose a `performance_monitor` factory on the service container
- instrument the discovery orchestrator to time both phases and publish summary metrics when a monitor is configured
- surface CLI flags and documentation for enabling monitoring and add regression tests covering the new paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf75c30cac832a9c4a3b4e5401ff10