### PR TITLE
Add phase1 regression tests for backtest engine and metrics

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level test package index."""
+
+__all__ = [
+    "phase1",
+]

--- a/tests/phase1/__init__.py
+++ b/tests/phase1/__init__.py
@@ -1,0 +1,6 @@
+"""Phase 1 specific regression tests."""
+
+__all__ = [
+    "test_backtest_engine_phase1",
+    "test_performance_metrics",
+]

--- a/tests/phase1/test_backtest_engine_phase1.py
+++ b/tests/phase1/test_backtest_engine_phase1.py
@@ -1,0 +1,95 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+
+from phase1.backtest_engine import SimpleBacktestEngine
+from utils.performance_metrics import PerformanceMetrics
+
+
+def _build_phase1_fixture():
+    index = pd.date_range("2024-03-01 09:30", periods=6, freq="1min")
+    close = pd.Series([100.0, 101.0, 99.0, 102.0, 101.0, 103.0], index=index)
+    data = pd.DataFrame(
+        {
+            "open": close,
+            "high": close + 0.5,
+            "low": close - 0.5,
+            "close": close,
+            "volume": [1000, 1100, 900, 1200, 950, 1300],
+        },
+        index=index,
+    )
+    # Missing the first timestamp to trigger the reindex branch and include NaNs.
+    signals = pd.Series([1.0, np.nan, -1.0, -1.0, 0.5], index=index[1:])
+    return data, signals
+
+
+def test_backtest_engine_phase1_metrics_with_nan_and_reindex(monkeypatch):
+    data, signals = _build_phase1_fixture()
+    engine = SimpleBacktestEngine("0700.HK", allocation=1.0)
+
+    base_cost_fn = engine.costs.calculate_total_cost
+    discount = 0.5
+    monkeypatch.setattr(
+        engine.costs,
+        "calculate_total_cost",
+        lambda trade_value: base_cost_fn(trade_value) * discount,
+    )
+
+    result = engine.backtest_factor(data, signals)
+
+    aligned_signals = signals.reindex(data.index).astype(float).fillna(0.0)
+    positions = aligned_signals.shift(1).fillna(0.0) * engine.allocation
+    returns = data["close"].pct_change().fillna(0.0).astype(float)
+    raw_strategy_returns = (returns * positions).astype(float)
+    previous_positions = positions.shift(1).fillna(0.0)
+    trade_changes = (positions - previous_positions).abs()
+    expected_trade_cost = base_cost_fn(engine.initial_capital * engine.allocation) * discount
+    expected_cost_drag = (trade_changes > 0).astype(float) * (
+        expected_trade_cost / engine.initial_capital
+    )
+    expected_strategy_returns = raw_strategy_returns - expected_cost_drag
+    expected_equity_curve = engine.initial_capital * (1 + expected_strategy_returns).cumprod()
+
+    pd.testing.assert_series_equal(
+        result["returns"], expected_strategy_returns, check_names=False
+    )
+    pd.testing.assert_series_equal(
+        result["equity_curve"], expected_equity_curve, check_names=False
+    )
+
+    assert result["trades_count"] == int((trade_changes > 0).sum())
+    expected_win_rate = float((expected_strategy_returns[trade_changes > 0] > 0).mean())
+    assert result["win_rate"] == pytest.approx(expected_win_rate)
+
+    strategy_array = expected_strategy_returns.to_numpy(dtype=float)
+    assert result["sharpe_ratio"] == pytest.approx(
+        PerformanceMetrics.calculate_sharpe_ratio(strategy_array)
+    )
+
+    gains = expected_strategy_returns[expected_strategy_returns > 0].to_numpy(dtype=float)
+    losses = expected_strategy_returns[expected_strategy_returns < 0].to_numpy(dtype=float)
+    assert result["profit_factor"] == pytest.approx(
+        PerformanceMetrics.calculate_profit_factor(gains, losses)
+    )
+
+    equity_array = expected_equity_curve.to_numpy(dtype=float)
+    assert result["max_drawdown"] == pytest.approx(
+        PerformanceMetrics.calculate_max_drawdown(equity_array)
+    )
+
+    future_returns = returns.shift(-1).fillna(0.0).to_numpy(dtype=float)
+    assert result["information_coefficient"] == pytest.approx(
+        PerformanceMetrics.calculate_information_coefficient(
+            aligned_signals.to_numpy(dtype=float), future_returns
+        )
+    )
+
+    pd.testing.assert_series_equal(
+        raw_strategy_returns - expected_strategy_returns,
+        expected_cost_drag,
+        check_names=False,
+    )
+
+    assert not signals.index.equals(data.index)

--- a/tests/phase1/test_performance_metrics.py
+++ b/tests/phase1/test_performance_metrics.py
@@ -1,0 +1,88 @@
+import math
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from utils.performance_metrics import PerformanceMetrics
+
+
+@pytest.mark.parametrize(
+    ("returns", "expected"),
+    [
+        ([], 0.0),
+        ([0.01, 0.01, 0.01], 0.0),
+    ],
+)
+def test_calculate_sharpe_ratio_edge_cases(returns, expected):
+    assert PerformanceMetrics.calculate_sharpe_ratio(returns) == pytest.approx(expected)
+
+
+def test_calculate_sharpe_ratio_matches_manual_formula():
+    returns = [0.01, -0.02, 0.03]
+    excess = np.asarray(returns, dtype=float) - 0.02 / 252.0
+    expected = float(np.sqrt(252) * excess.mean() / excess.std(ddof=1))
+    assert PerformanceMetrics.calculate_sharpe_ratio(returns) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "returns",
+    [
+        [],
+        [0.01, 0.01, 0.01],
+    ],
+)
+def test_calculate_stability_edge_cases(returns):
+    if not returns:
+        expected = 0.0
+    else:
+        array = np.asarray(returns, dtype=float)
+        cumulative_returns = np.cumprod(1 + array)
+        x = np.arange(len(cumulative_returns), dtype=float)
+        x_mean = x.mean()
+        y_mean = cumulative_returns.mean()
+        cov = np.mean((x - x_mean) * (cumulative_returns - y_mean))
+        var_x = np.mean((x - x_mean) ** 2)
+        var_y = np.mean((cumulative_returns - y_mean) ** 2)
+        expected = 0.0 if var_x == 0 or var_y == 0 else float((cov / np.sqrt(var_x * var_y)) ** 2)
+    assert PerformanceMetrics.calculate_stability(returns) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("gains", "losses", "expected"),
+    [
+        ([], [], 0.0),
+        ([0.02], [], math.inf),
+        ([0.01, 0.02], [-0.02], 1.5),
+    ],
+)
+def test_calculate_profit_factor_edge_cases(gains, losses, expected):
+    result = PerformanceMetrics.calculate_profit_factor(gains, losses)
+    if math.isinf(expected):
+        assert math.isinf(result)
+    else:
+        assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("equity", "expected"),
+    [
+        ([], 0.0),
+        ([100.0, 120.0, 90.0, 95.0], 0.25),
+    ],
+)
+def test_calculate_max_drawdown_edge_cases(equity, expected):
+    assert PerformanceMetrics.calculate_max_drawdown(equity) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("signals", "future_returns", "expected"),
+    [
+        ([], [], 0.0),
+        ([np.nan, np.nan], [0.01, 0.02], 0.0),
+        ([0.1, np.nan, -0.2, 0.3], [0.05, 0.01, np.nan, 0.04], -1.0),
+    ],
+)
+def test_calculate_information_coefficient_with_nans(signals, future_returns, expected):
+    result = PerformanceMetrics.calculate_information_coefficient(signals, future_returns)
+    assert result == pytest.approx(expected, abs=1e-12)


### PR DESCRIPTION
## Summary
- add a phase1 test package with an index to expose the new regression modules
- verify SimpleBacktestEngine handles NaN signals, reindexing, and discounted trading costs while reporting metrics
- add parameterized PerformanceMetrics tests that cover empty inputs, constant sequences, and NaN-heavy information coefficients

## Testing
- pytest tests/phase1

------
https://chatgpt.com/codex/tasks/task_e_68cfb79ad734832a873470d80a35d5c1